### PR TITLE
make sure we install and use certbot only when we use letsencrypt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 
 - import_tasks: build.yml
+  when: nginx_use_letsencrypt|bool == true
   become: yes
   tags: [certbot, build]


### PR DESCRIPTION
if ssl_key and ssl_cert are supplied we don't need to install certbot. useful for test installs or when we already have the certificate available.